### PR TITLE
undergarments fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -21,10 +21,10 @@
     - map: [ "enum.HumanoidVisualLayers.LLeg" ]
     - map: ["enum.HumanoidVisualLayers.LFoot"] # reordered
     - map: ["enum.HumanoidVisualLayers.RFoot"]
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: ["enum.HumanoidVisualLayers.Undergarments"] # google's gaggle land
     - map: ["jumpsuit"]
+    - map: ["enum.HumanoidVisualLayers.LHand"]
+    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "gloves" ]
     - map: [ "shoes" ]
     - map: [ "ears" ]

--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -51,6 +51,9 @@
       points: 1
       required: true
       defaultMarkings: [ MobIPCHeadDefault ]
+    Undergarments: # google's gaggle land
+      points: 4
+      required: false
     Chest:
       points: 1
       required: true

--- a/Resources/Prototypes/_Gaggle/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/_Gaggle/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -2,7 +2,7 @@
   id: UndergarmentMaleBriefs
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_briefs
@@ -11,7 +11,7 @@
   id: UndergarmentMaleBoxers
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_boxers
@@ -20,7 +20,7 @@
   id: UndergarmentMaleBoxersStriped
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_boxers
@@ -31,7 +31,7 @@
   id: UndergarmentMaleBoxersHearts
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_boxers
@@ -43,7 +43,7 @@
   id: UndergarmentMaleMidway
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_midway
@@ -52,6 +52,7 @@
   id: UndergarmentMaleLongJohns
   bodyPart: Undergarments
   markingCategory: Undergarments
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_longjohns
@@ -60,7 +61,7 @@
   id: UndergarmentMaleShirt
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_shirt
@@ -69,7 +70,7 @@
   id: UndergarmentMaleShirtShortSleeved
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_shortsleeve
@@ -78,7 +79,7 @@
   id: UndergarmentMaleTankTop
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_tank
@@ -87,7 +88,7 @@
   id: UndergarmentMaleTankTopAlt
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: male_tank_alt
@@ -96,7 +97,7 @@
   id: UndergarmentFemaleBikini
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_bikini
@@ -105,7 +106,7 @@
   id: UndergarmentFemaleBralette
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_bralette
@@ -114,7 +115,7 @@
   id: UndergarmentFemaleSportswear
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_sport
@@ -123,7 +124,7 @@
   id: UndergarmentFemaleSportsBra
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_sportsbra
@@ -132,7 +133,7 @@
   id: UndergarmentFemaleSportsBraAlt
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_sportsbra_alt
@@ -141,7 +142,7 @@
   id: UndergarmentFemaleSwimTwoPiece
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_swim_twopiece
@@ -150,7 +151,7 @@
   id: UndergarmentFemaleShirt
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_shirt
@@ -159,7 +160,7 @@
   id: UndergarmentFemaleShirtShortSleeved
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_shortsleeve
@@ -168,7 +169,7 @@
   id: UndergarmentFemaleTankTop
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_tank
@@ -177,7 +178,7 @@
   id: UndergarmentFemaleTankTopAlt
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_tank_alt
@@ -186,7 +187,7 @@
   id: UndergarmentFemaleTop
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_top
@@ -195,7 +196,7 @@
   id: UndergarmentFemaleBottom
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: female_bottom
@@ -204,7 +205,7 @@
   id: UndergarmentSocks
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks
@@ -213,7 +214,7 @@
   id: UndergarmentSocksShort
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_short
@@ -222,7 +223,7 @@
   id: UndergarmentSocksKnee
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_knee
@@ -231,7 +232,7 @@
   id: UndergarmentSocksThigh
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_thigh
@@ -240,7 +241,7 @@
   id: UndergarmentSocksKneeStriped
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_knee
@@ -251,7 +252,7 @@
   id: UndergarmentSocksThighStriped
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_thigh
@@ -262,7 +263,7 @@
   id: UndergarmentSocksThinKnee
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_thin_knee
@@ -271,7 +272,7 @@
   id: UndergarmentSocksThinThigh
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: socks_thin_thigh
@@ -280,7 +281,7 @@
   id: UndergarmentPantyhose
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: pantyhose
@@ -289,7 +290,7 @@
   id: UndergarmentFishnetKnee
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: fishnet_knee
@@ -298,7 +299,7 @@
   id: UndergarmentFishnetThigh
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: fishnet_thigh
@@ -307,7 +308,7 @@
   id: UndergarmentFishnetFull
   bodyPart: Undergarments
   markingCategory: Undergarments
-  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal]
+  speciesRestriction: [Dwarf, Human, Arachnid, Felinid, Vulpkanin, Rodentia, Reptilian, Ethereal, SlimePerson, Gingerbread]
   sprites:
     - sprite: _gaggle/Mobs/Customization/undergarments.rsi
       state: fishnet_full


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
hands were below jumpsuit layer, IPCs now have undergarment restrictions, gingerbread people and slime people can now wear undergarments

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed hands being visually below the jumpsuit on certain species
- tweak: Gingerbread people and Slime people can now wear undergarments