### PR TITLE
Meteors PR but fixed, probably?

### DIFF
--- a/Content.Server/StationEvents/Components/MeteorSwarmComponent.cs
+++ b/Content.Server/StationEvents/Components/MeteorSwarmComponent.cs
@@ -51,8 +51,8 @@ public sealed partial class MeteorSwarmComponent : Component
     public MinMax Waves = new(3, 3);
 
     [DataField]
-    public MinMax MeteorsPerWave = new(3, 4);
+    public MinMax MeteorsPerWave = new(1, 2);
 
     [DataField]
-    public MinMax WaveCooldown = new (10, 60);
+    public MinMax WaveCooldown = new (30, 70);
 }

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -2,28 +2,28 @@
   id: DefaultMapPool
   maps:
   - Amber
-  #- Atlas
-  #- Bagel
-  #- Box
-  #- Cluster
+  - Atlas
+  - Bagel
+  - Box
+  - Cluster
   #- Pillbug
   #- Cog # Goobstation - cog is broken
-  #- Core
-  #- Elkridge
-  #- Fland
-  #- Marathon
-  #- Meta
-  #- Oasis
-  #- Omega
-  #- Origin
+  - Core
+  - Elkridge
+  - Fland
+  - Marathon
+  - Meta
+  - Oasis
+  - Omega
+  - Origin
   - Saltern
   - Packed
   - Reach # funkystation - operation revive lrp
-  #- roid_outpost
-  #- Train - Train is pain
-  #- FlandHighPop
-  #- OasisHighPop
-  #- Barratry # Goobstation - Re-add barratry - Funkystation - Barratrauma
-  #- Kettle
+  - roid_outpost
+  - Train - Train is pain
+  - FlandHighPop
+  - OasisHighPop
+  - Barratry # Goobstation - Re-add barratry - Funkystation - Barratrauma
+  - Kettle
   - Uoui
-  - ResearchOutpost
+  #- ResearchOutpost

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
@@ -84,7 +84,7 @@
     - Dynamic
     - BasicStationEventSchedulerNoAntag
     - DynamicStationEventScheduler
-    #- MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler
     - BasicRoundstartVariation

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -11,7 +11,7 @@
     - Changeling
     - SubGamemodesRule
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
 - type: gamePreset
@@ -27,7 +27,7 @@
     - CalmTraitor
     - SubGamemodesRule
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
 - type: gamePreset
@@ -58,7 +58,7 @@
     - Calmops
     - CalmLing
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
 - type: gamePreset
@@ -74,7 +74,7 @@
     - CalmRevs
     - CalmTraitor
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
 
 - type: gamePreset
   id: RevLing
@@ -89,7 +89,7 @@
     - CalmLing
     - SubGamemodesRule
     - BasicStationEventScheduler
-    #- MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
     - BasicRoundstartVariation
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -6,7 +6,7 @@
   showInVote: false # secret
   description: survival-description
   rules:
-    # - MeteorSwarmScheduler Goobstation - nuh uh
+     - MeteorSwarmScheduler Goobstation - nuh uh
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler
@@ -85,7 +85,7 @@
   description: extended-description
   rules:
   - BasicStationEventScheduler
-  # - MeteorSwarmScheduler Goobstation - nuh uh
+   - MeteorSwarmScheduler Goobstation - nuh uh
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
@@ -187,7 +187,7 @@
     - Nukeops
     - SubGamemodesRule
     - BasicStationEventScheduler
-  #  - MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -204,7 +204,7 @@
     - Revolutionary
     - SubGamemodesRule
     - BasicStationEventScheduler
-  #  - MeteorSwarmScheduler Goobstation - nuh uh
+    - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
 
@@ -237,7 +237,7 @@
   rules:
   - Zombie
   - BasicStationEventScheduler
-#  - MeteorSwarmScheduler Goobstation - nuh uh
+  - MeteorSwarmScheduler Goobstation - nuh uh
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 


### PR DESCRIPTION
Ya boy didn't know you have to commit the specific changes you wanna PR and make a branch for it so my PR was fucked up, whoo!

Makes meteors happen again, but less frequently and with less amount of meteors (for now)

Meteors shouldn't happen on super lowpop (thats a basegame wizden thing, not mine) don't worry about that :) !

PR to give more chaos to game and something for engineer players to do. Probably gonna be tweaked in the future. If this PR is fucked up again kill me pls