### PR TITLE
DEMOCRACY / Default gamemode = Dynamic

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -33,7 +33,7 @@ public sealed partial class CCVars
     ///     Controls the default game preset.
     /// </summary>
     public static readonly CVarDef<string>
-        GameLobbyDefaultPreset = CVarDef.Create("game.defaultpreset", "secret", CVar.ARCHIVE);
+        GameLobbyDefaultPreset = CVarDef.Create("game.defaultpreset", "dynamic", CVar.ARCHIVE);
 
     /// <summary>
     ///     Controls if the game can force a different preset if the current preset's criteria are not met.

--- a/Content.Shared/CCVar/CCVars.Vote.cs
+++ b/Content.Shared/CCVar/CCVars.Vote.cs
@@ -38,7 +38,7 @@ public sealed partial class CCVars
     ///     See vote.enabled, but specific to map votes
     /// </summary>
     public static readonly CVarDef<bool> VoteMapEnabled =
-        CVarDef.Create("vote.map_enabled", false, CVar.SERVERONLY);
+        CVarDef.Create("vote.map_enabled", true, CVar.SERVERONLY);
 
     /// <summary>
     ///     The required ratio of the server that must agree for a restart round vote to go through.
@@ -50,7 +50,7 @@ public sealed partial class CCVars
     /// Whether or not to prevent the restart vote from having any effect when there is an online admin
     /// </summary>
     public static readonly CVarDef<bool> VoteRestartNotAllowedWhenAdminOnline =
-        CVarDef.Create("vote.restart_not_allowed_when_admin_online", true, CVar.SERVERONLY);
+        CVarDef.Create("vote.restart_not_allowed_when_admin_online", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     The delay which two votes of the same type are allowed to be made by separate people, in seconds.

--- a/Resources/Prototypes/_Funkystation/game_presets.yml
+++ b/Resources/Prototypes/_Funkystation/game_presets.yml
@@ -19,7 +19,7 @@
   - heret
   name: heretics-gamemode-title
   description: heretics-gamemode-description
-  showInVote: false
+  showInVote: true
   rules:
   - CalmHeretic
   - CalmTraitor
@@ -34,7 +34,7 @@
   - changehere
   name: heretics-gamemode-title
   description: heretics-gamemode-description
-  showInVote: false
+  showInVote: true
   rules:
   - CalmHeretic
   - CalmLing
@@ -50,7 +50,7 @@
   - TotsBlob
   name: blob-title
   description: blob-description
-  showInVote: false
+  showInVote: true
   rules:
   - CalmTraitor
   - BlobGameMode

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -6,7 +6,7 @@
     - changeling
   name: changeling-gamemode-title
   description: changeling-gamemode-description
-  showInVote: false
+  showInVote: true
   rules:
     - Changeling
     - SubGamemodesRule
@@ -21,7 +21,7 @@
     - traitorling
   name: traitorling-title
   description: traitorling-description
-  showInVote: false
+  showInVote: true
   rules:
     - CalmLing
     - CalmTraitor
@@ -38,7 +38,7 @@
     - optot
   name: nukeops-title
   description: nukeops-description
-  showInVote: false
+  showInVote: true
   rules:
     - Calmops
     - CalmTraitor
@@ -53,7 +53,7 @@
     - opling
   name: nukeops-title
   description: nukeops-description
-  showInVote: false
+  showInVote: true
   rules:
     - Calmops
     - CalmLing
@@ -69,7 +69,7 @@
     - totrevs
   name: revtraitor-title
   description: revtraitor-description
-  showInVote: false
+  showInVote: true
   rules:
     - CalmRevs
     - CalmTraitor
@@ -83,7 +83,7 @@
     - lingrevs
   name: revling-title
   description: revling-description
-  showInVote: false
+  showInVote: true
   rules:
     - CalmRevs
     - CalmLing
@@ -99,7 +99,7 @@
   - blab
   name: blob-title
   description: blob-description
-  showInVote: false
+  showInVote: true
   rules:
   - BlobGameMode
   - BasicStationEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -3,7 +3,7 @@
   alias:
     - survival
   name: survival-title
-  showInVote: false # secret
+  showInVote: true # secret
   description: survival-description
   rules:
     - MeteorSwarmScheduler
@@ -19,7 +19,7 @@
     - junk
     - meteorhell
   name: kessler-syndrome-title
-  showInVote: false # secret
+  showInVote: true # secret
   description: kessler-syndrome-description
   rules:
     - KesslerSyndromeScheduler
@@ -33,7 +33,7 @@
   - all
   name: all-at-once-title
   description: all-at-once-description
-  showInVote: false
+  showInVote: true
   rules:
     - Nukeops
     - Traitor
@@ -56,7 +56,7 @@
   - punishment
   name: aller-at-once-title
   description: aller-at-once-description
-  showInVote: false #Please god dont do this
+  showInVote: true #Please god dont do this
   rules:
     - CosmicCult
     - Nukeops
@@ -154,7 +154,7 @@
     - tator
   name: traitor-title
   description: traitor-description
-  showInVote: false
+  showInVote: true
   rules:
     - Traitor
     - SubGamemodesRule
@@ -182,7 +182,7 @@
     - nukeops
   name: nukeops-title
   description: nukeops-description
-  showInVote: false
+  showInVote: true
   rules:
     - Nukeops
     - SubGamemodesRule
@@ -199,7 +199,7 @@
     - revolutionaries
   name: rev-title
   description: rev-description
-  showInVote: false
+  showInVote: true
   rules:
     - Revolutionary
     - SubGamemodesRule
@@ -214,7 +214,7 @@
   - wizard
   name: wizard-title
   description: wizard-description
-  showInVote: false
+  showInVote: true
   rules:
   - Wizard
   #- SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine
@@ -233,7 +233,7 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  showInVote: false
+  showInVote: true
   rules:
   - Zombie
   - BasicStationEventScheduler
@@ -249,7 +249,7 @@
   - meteombies
   name: zombieteors-title
   description: zombieteors-description
-  showInVote: false
+  showInVote: true
   rules:
   - Zombie
   - BasicStationEventScheduler


### PR DESCRIPTION
The default gamemode is "Dynamic" instead of "Secret" due to low population.

Non-Admins can conduct the following votes when they please :

Next map (this is still balanced in choices by the server population)
Next gamemode (literally all except for extended and greenshift (they are boring) )
Restart round ( Democracy )

This means if you want to vote nukies to go do roleplay on the nukie planet with a population of, like, two? You can do it. Knock yourself out. If you want zombies? You can do it. Yeah.

Can be edited / rebalanced in updates. :) !

You get what you wish for, if you vote for aller at once and its horrific ; that's on you man.

Notes :

 - Added fun!!!!!
- Tested if this actually works but only with myself lol