### PR TITLE
Possessive emotes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -599,7 +599,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool hideLog = false,
         bool checkEmote = true,
         bool ignoreActionBlocker = false,
-        NetUserId? author = null
+        NetUserId? author = null,
+        RadioChannelPrototype? channel = null
         )
     {
         if (!_actionBlocker.CanEmote(source) && !ignoreActionBlocker)
@@ -610,14 +611,32 @@ public sealed partial class ChatSystem : SharedChatSystem
         string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
 
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
-        var wrappedMessage = Loc.GetString("chat-manager-entity-me-wrap-message",
+        var messageWrapper = "chat-manager-entity-me-wrap-message";
+        var formattedAction = FormattedMessage.RemoveMarkupOrThrow(action);
+
+        // gaggle! Possesive emotes. "Urist McHands 's eyes blink"|"Urist McHands s eyes blink" -> "Urist McHands's eyes blink"
+        if (formattedAction.StartsWith("'s ") ||
+            formattedAction.StartsWith("s "))
+        {
+            var substringIndex = formattedAction.StartsWith("s ") ?
+                2 :
+                3;
+
+            messageWrapper = "chat-manager-entity-me-wrap-message-possessive";
+            formattedAction = formattedAction[substringIndex..];
+        }
+
+        var wrappedMessage = Loc.GetString(messageWrapper,
             ("entityName", name),
             ("entity", ent),
-            ("message", FormattedMessage.RemoveMarkupOrThrow(action)));
+            ("message", formattedAction));
 
         if (checkEmote)
             TryEmoteChatInput(source, action);
         SendInVoiceRange(ChatChannel.Emotes, action, wrappedMessage, source, range, author);
+
+        // TODO : RADIO EMOTES
+
         if (!hideLog)
             if (name != Name(source))
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user} as {name}: {action}");

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -33,6 +33,10 @@ chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
     *[false] The {$entityName} {$message}[/italic]
      [true] {CAPITALIZE($entityName)} {$message}[/italic]
     }
+chat-manager-entity-me-wrap-message-possessive = [italic]{ PROPER($entity) ->
+    *[false] The {$entityName} {$message}[/italic]
+     [true] {CAPITALIZE($entityName)}'s {$message}[/italic]
+    }
 
 chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$message}
 chat-manager-send-ooc-wrap-message = OOC: [bold]{$playerName}:[/bold] {$message}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the ability to do possessive emotes such as "John Doe's eye twitches", instead of it being "John Doe 's eye twitches"

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Immersion and roleplay

## Technical details
<!-- Summary of code changes for easier review. -->
- `ChatSystem.SendEntityEmote` now takes in a `RadioChannelPrototype?` parameter `channel` *(unused as of now)*
- `ChatSystem.SendEntityEmote` now checks for `"'s "` and `"s "` at the start of the message, and uses `chat-manager-entity-me-wrap-message-possessive` locale instead of `chat-manager-entity-me-wrap-message` if successful
- Added `chat-manager-entity-me-wrap-message-possessive` locale

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1220" height="446" alt="image" src="https://github.com/user-attachments/assets/e1b73553-0e9b-4283-908d-1839e5a5a78f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl: miapyxel2
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: miapyxel2
- tweak: Possessive emotes, "John Doe 's hands shake" now turns into "John Doe's hands shake"